### PR TITLE
Add execution plan for Inab Budget App

### DIFF
--- a/inab-tasks.md
+++ b/inab-tasks.md
@@ -3,7 +3,7 @@
 ## 1. Load PRP
 - Read and understand the Inab Budget App Base PRP (`PRPs/inab-budget-base.md`) to capture goals, deliverables, and success criteria
 - Review supporting docs: YNAB basics (`PRPs/ai_docs/ynab_basics.md`) and execution guide (`.claude/commands/typescript/TS-execute-base-prp.md`)
-- Consult repository guidelines (`AGENTS.md`, `CLAUDE.md`, `README.md`) for project conventions and context
+- Consult repository guidelines (`AGENTS.md`, `CLAUDE.md`) for project conventions and context
 - Gather additional references: TypeScript docs, Next.js routing docs, React `useReducer`
 
 ## 2. Ultrathink

--- a/ynab.md
+++ b/ynab.md
@@ -1,0 +1,39 @@
+# Inab Budget App Execution Plan
+
+## 1. Load PRP
+- Read and understand the Inab Budget App Base PRP (`PRPs/inab-budget-base.md`) to capture goals, deliverables, and success criteria
+- Review supporting docs: YNAB basics (`PRPs/ai_docs/ynab_basics.md`) and execution guide (`.claude/commands/typescript/TS-execute-base-prp.md`)
+- Consult repository guidelines (`AGENTS.md`, `CLAUDE.md`, `README.md`) for project conventions and context
+- Gather additional references: TypeScript docs, Next.js routing docs, React `useReducer`
+
+## 2. Ultrathink
+- Break down the PRP into actionable tasks and ensure clarity before coding
+
+## 3. Implementation Tasks
+1. Create a Next.js 14 TypeScript project in the repository root
+2. Define `Account`, `Category`, and `Transaction` interfaces in `lib/types/budget.ts`
+3. Implement async JSON read/write helpers in `lib/types/storage.ts`
+4. Build `app/api/categories/route.ts` with GET, POST, PUT, DELETE handlers using storage helpers and `Category` interface
+5. Build `app/api/accounts/route.ts` with corresponding CRUD handlers using storage helpers and `Account` interface
+6. Build `app/api/transactions/route.ts` with GET, POST, DELETE handlers using storage helpers and `Transaction` interface
+7. Create `components/CategoryList.tsx` to show budgeted, activity, and available for each category via categories API
+8. Create `components/TransactionForm.tsx` to add income or expense transactions using categories/accounts for selection
+9. Create `components/TransactionList.tsx` to display transaction history grouped by date via transactions API
+10. Modify `app/page.tsx` as a client component with `'use client'`, aggregating the above components and managing local state with `useReducer`
+
+## 4. Validate
+- Run lint, typecheck, and formatting commands
+- Execute unit tests via `npm test`
+- Perform integration tests: build, start server, and verify endpoints using `curl`
+- Run additional strict TypeScript and lint checks
+
+## 5. Complete
+- Confirm all checklist items: technical, feature, code quality, and documentation validations
+- Ensure no anti-patterns such as skipping type annotations or mutating state directly are present
+- Re-read the PRP to verify all requirements are met
+
+## 6. Reference PRP
+- Keep the PRP accessible for future iterations and context refreshers
+
+### Notes
+- This plan follows the TS execute process: load, ultrathink, execute, validate, and complete, ensuring alignment with the project’s PRP.


### PR DESCRIPTION
## Summary
- add `ynab.md` outlining a detailed execution plan for implementing the Inab Budget App
- reference relevant project files for PRP and guidelines

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run typecheck` *(fails: Could not read package.json)*
- `npm run format` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c562170810832bb828387e7c0de659